### PR TITLE
Fix StatsTracker null pointer

### DIFF
--- a/src/main/java/com/queue/file/controller/StatsTracker.java
+++ b/src/main/java/com/queue/file/controller/StatsTracker.java
@@ -25,7 +25,7 @@ public class StatsTracker {
     }
 
     public void keepRecord(String partitionName, String executorName, long count, ActionType actionType) {
-        InOutStorage ioStorage = parttitionInOutInfoMap.get(partitionName);
+        InOutStorage ioStorage = parttitionInOutInfoMap.computeIfAbsent(partitionName, k -> new InOutStorage());
         switch (actionType) {
             case INPUT:
                 addTOTAL_INPUT_COUNT(count);


### PR DESCRIPTION
## Summary
- prevent NPE in StatsTracker when a partition is first seen

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_687ed2fb1fec832c9c31719789dc10c3