### PR TITLE
Add additional unit tests

### DIFF
--- a/src/test/java/com/queue/file/controller/DataAccessTest.java
+++ b/src/test/java/com/queue/file/controller/DataAccessTest.java
@@ -1,0 +1,60 @@
+package com.queue.file.controller;
+
+import com.queue.file.vo.*;
+import org.h2.mvstore.MVStore;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class DataAccessTest {
+
+    @Test
+    public void testWriteAndRead() throws Exception {
+        Path file = Files.createTempFile("queue", ".mv");
+        FileQueueConfigVo config = new FileQueueConfigVo(file.getParent().toString(), file.getFileName().toString());
+        StoreInfo storeInfo = new StoreInfo(config);
+        storeInfo.setStore(new MVStore.Builder().open());
+        storeInfo.setStoreOpenTime(LocalDateTime.now());
+        PartitionManager pm = new PartitionManager(storeInfo);
+        DataAccess da = new DataAccess(storeInfo, pm);
+
+        String partition = "p1";
+        String executor = "exec";
+        da.write("tag", partition, executor, "data1");
+        FileQueueData read = da.read(partition, executor);
+        assertNotNull(read);
+        assertEquals("data1", read.getData());
+        da.readCommit(partition, executor);
+
+        Files.deleteIfExists(file);
+    }
+
+    @Test
+    public void testWriteBulkReadBulk() throws Exception {
+        Path file = Files.createTempFile("queue", ".mv");
+        FileQueueConfigVo config = new FileQueueConfigVo(file.getParent().toString(), file.getFileName().toString());
+        StoreInfo storeInfo = new StoreInfo(config);
+        storeInfo.setStore(new MVStore.Builder().open());
+        storeInfo.setStoreOpenTime(LocalDateTime.now());
+        PartitionManager pm = new PartitionManager(storeInfo);
+        DataAccess da = new DataAccess(storeInfo, pm);
+
+        String partition = "p2";
+        String executor = "exec";
+        List<String> dataList = Arrays.asList("d1", "d2", "d3");
+        da.writeBulk("tag", partition, executor, dataList);
+        List<FileQueueData> readList = da.read(partition, executor, 3);
+        assertNotNull(readList);
+        assertEquals(3, readList.size());
+        assertEquals("d1", readList.get(0).getData());
+        da.readCommit(partition, executor);
+
+        Files.deleteIfExists(file);
+    }
+}

--- a/src/test/java/com/queue/file/controller/PartitionManagerTest.java
+++ b/src/test/java/com/queue/file/controller/PartitionManagerTest.java
@@ -1,0 +1,40 @@
+package com.queue.file.controller;
+
+import com.queue.file.utils.Contents;
+import com.queue.file.vo.*;
+import org.h2.mvstore.MVMap;
+import org.h2.mvstore.MVStore;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+
+public class PartitionManagerTest {
+
+    @Test
+    public void testRealignDataKey() throws Exception {
+        Path file = Files.createTempFile("queue", ".mv");
+        FileQueueConfigVo config = new FileQueueConfigVo(file.getParent().toString(), file.getFileName().toString());
+        StoreInfo storeInfo = new StoreInfo(config);
+        storeInfo.setStore(new MVStore.Builder().open());
+        storeInfo.setStoreOpenTime(LocalDateTime.now());
+        PartitionManager pm = new PartitionManager(storeInfo);
+
+        PartitionContext ctx = pm.getPartitionContext("P1");
+        MVMap<Long, FileQueueData> map = ctx.getDataMap();
+        map.put(1L, new FileQueueData("P1", "t", "d1"));
+        map.put(2L, new FileQueueData("P1", "t", "d2"));
+
+        assertTrue(ctx.getTransactionKeyList().isEmpty());
+        pm.realignDataKey("P1");
+        assertEquals(2, ctx.getTransactionKeyList().size());
+        assertTrue(ctx.getTransactionKeyList().containsAll(Arrays.asList(1L,2L)));
+        assertNotNull(ctx.getSyncInfo());
+
+        Files.deleteIfExists(file);
+    }
+}

--- a/src/test/java/com/queue/file/controller/StatsTrackerTest.java
+++ b/src/test/java/com/queue/file/controller/StatsTrackerTest.java
@@ -1,0 +1,57 @@
+package com.queue.file.controller;
+
+import com.queue.file.vo.*;
+import org.h2.mvstore.MVStore;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.*;
+
+public class StatsTrackerTest {
+
+    @Test
+    public void testKeepRecordCounts() {
+        StatsTracker tracker = new StatsTracker();
+        String partition = "P1";
+        String exec = "EXEC";
+
+        tracker.keepRecord(partition, exec, 2, ActionType.INPUT);
+        tracker.keepRecord(partition, exec, 1, ActionType.OUTPUT);
+        tracker.keepRecord(partition, exec, 3, ActionType.BUFFER_INPUT);
+        tracker.keepRecord(partition, exec, 4, ActionType.BUFFER_OUTPUT);
+
+        InOutStorage info = tracker.getInOutInfo(partition);
+        assertEquals(Long.valueOf(2), info.getInputCount());
+        assertEquals(Long.valueOf(1), info.getOutputCount());
+        assertEquals(Long.valueOf(3), info.getBufferInputCount());
+        assertEquals(Long.valueOf(4), info.getBufferOutputCount());
+
+        assertEquals(Long.valueOf(2), tracker.getTOTAL_INPUT_COUNT());
+        assertEquals(Long.valueOf(1), tracker.getTOTAL_OUTPUT_COUNT());
+    }
+
+    @Test
+    public void testDataAccessSimpleFlow() throws Exception {
+        Path dummyFile = Files.createTempFile("queue", ".mv");
+        FileQueueConfigVo config = new FileQueueConfigVo(dummyFile.getParent().toString(), dummyFile.getFileName().toString());
+        StoreInfo storeInfo = new StoreInfo(config);
+        storeInfo.setStore(new MVStore.Builder().open());
+        storeInfo.setStoreOpenTime(LocalDateTime.now());
+        PartitionManager pm = new PartitionManager(storeInfo);
+        DataAccess da = new DataAccess(storeInfo, pm);
+
+        String partition = "part";
+        String exec = "exec";
+        da.write("tag", partition, exec, "data1");
+        FileQueueData data = da.read(partition, exec);
+        assertNotNull(data);
+        assertEquals("data1", data.getData());
+        da.readCommit(partition, exec);
+
+        Files.deleteIfExists(dummyFile);
+    }
+}
+


### PR DESCRIPTION
## Summary
- create `DataAccessTest` for basic single and bulk read/write flows
- add `PartitionManagerTest` to verify realignDataKey updates key list

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ed5631480832cba0482db22448f90