### PR TITLE
Add tests and restore plugin config

### DIFF
--- a/src/test/java/com/queue/file/controller/BaseControllerTest.java
+++ b/src/test/java/com/queue/file/controller/BaseControllerTest.java
@@ -1,0 +1,48 @@
+package com.queue.file.controller;
+
+import com.queue.file.utils.Contents;
+import com.queue.file.vo.*;
+import org.h2.mvstore.MVStore;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+public class BaseControllerTest {
+
+    @Test
+    public void testWriteReadAndSummary() throws Exception {
+        Path file = Files.createTempFile("queue", ".mv");
+        FileQueueConfigVo config = new FileQueueConfigVo(file.getParent().toString(), file.getFileName().toString());
+        StoreInfo storeInfo = new StoreInfo(config);
+        storeInfo.setStore(new MVStore.Builder().open());
+        storeInfo.setStoreOpenTime(LocalDateTime.now());
+
+        BaseController controller = new BaseController(storeInfo);
+
+        controller.write("data1");
+        FileQueueData read = controller.read();
+        assertNotNull(read);
+        assertEquals("data1", read.getData());
+        controller.readCommit(Thread.currentThread().getName());
+
+        Map<String, List<FileQueueData>> allData = controller.getAllDataList();
+        assertTrue(allData.get(Contents.DEFAULT_PARTITION).isEmpty());
+
+        controller.write("P1", "data2");
+        Set<String> names = controller.getAllPartitionNameSet();
+        assertTrue(names.contains("P1"));
+
+        Map<String, PartitionSummaryVo> summary = controller.getSummaryInfo();
+        assertEquals(1, summary.get("P1").getDataCount());
+
+        storeInfo.getStore().close();
+        Files.deleteIfExists(file);
+    }
+}

--- a/src/test/java/com/queue/file/controller/ControllerFactoryTest.java
+++ b/src/test/java/com/queue/file/controller/ControllerFactoryTest.java
@@ -1,0 +1,61 @@
+package com.queue.file.controller;
+
+import com.queue.file.exception.InitializeException;
+import com.queue.file.utils.Contents;
+import com.queue.file.vo.FileQueueData;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class ControllerFactoryTest {
+
+    @Test
+    public void testCreateAndBasicIO() throws Exception {
+        Path dir = Files.createTempDirectory("qtest");
+        String queue = dir.resolve("t.mv").toString();
+
+        BaseController controller = ControllerFactory.create(queue);
+        assertNotNull(controller);
+
+        controller.write("hello");
+        FileQueueData data = controller.read();
+        assertNotNull(data);
+        assertEquals("hello", data.getData());
+        controller.readCommit(Thread.currentThread().getName());
+
+        controller.getStoreInfo().getStore().close();
+        Files.deleteIfExists(dir.resolve("t.mv"));
+        Files.deleteIfExists(dir);
+    }
+
+    @Test
+    public void testStableModeBuffer() throws Exception {
+        Path dir = Files.createTempDirectory("stable");
+        String queue = dir.resolve("s.mv").toString();
+
+        BaseController controller = ControllerFactory.createStable(queue);
+        controller.write("hello");
+
+        FileQueueData data = controller.read();
+        assertNotNull(data);
+        Map<String, List<FileQueueData>> buffers = controller.getPartitionBufferList(Contents.DEFAULT_PARTITION);
+        assertTrue(buffers.containsKey(Thread.currentThread().getName()));
+        controller.readCommit(Thread.currentThread().getName());
+        buffers = controller.getPartitionBufferList(Contents.DEFAULT_PARTITION);
+        assertFalse(buffers.containsKey(Thread.currentThread().getName()));
+
+        controller.getStoreInfo().getStore().close();
+        Files.deleteIfExists(dir.resolve("s.mv"));
+        Files.deleteIfExists(dir);
+    }
+
+    @Test(expected = InitializeException.class)
+    public void testCreateInvalidPath() {
+        ControllerFactory.create("/not/exist/path/queue.mv");
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for `BaseController`
- add unit tests for `ControllerFactory`
- restore previously removed plugins in `pom.xml`

## Testing
- `mvn -q test` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_e_6880378376b4832c8feef6529bf149f1