### PR TITLE
Add simple producer/consumer samples

### DIFF
--- a/src/test/com/queue/sample/ConsumerSample.java
+++ b/src/test/com/queue/sample/ConsumerSample.java
@@ -1,0 +1,46 @@
+package com.queue.file.sample;
+
+import com.queue.file.controller.BaseController;
+import com.queue.file.exception.QueueReadException;
+import com.queue.file.vo.FileQueueData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Sample consumer that reads messages using BaseController.
+ */
+public class ConsumerSample implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(ConsumerSample.class);
+
+    private final BaseController controller;
+    private volatile boolean run = true;
+
+    public ConsumerSample(BaseController controller) {
+        this.controller = controller;
+    }
+
+    @Override
+    public void run() {
+        String executor = Thread.currentThread().getName();
+        while (run) {
+            try {
+                List<FileQueueData> list = controller.read(executor, 5);
+                if (list != null && !list.isEmpty()) {
+                    for (FileQueueData data : list) {
+                        logger.info("consumed: {}", data.getData());
+                    }
+                    controller.readCommit(executor);
+                    break; // exit after one batch for sample
+                }
+                Thread.sleep(500);
+            } catch (InterruptedException e) {
+                run = false;
+            } catch (QueueReadException e) {
+                run = false;
+                throw new RuntimeException(e);
+            }
+        }
+    }
+}

--- a/src/test/com/queue/sample/ProducerSample.java
+++ b/src/test/com/queue/sample/ProducerSample.java
@@ -1,0 +1,36 @@
+package com.queue.file.sample;
+
+import com.queue.file.controller.BaseController;
+import com.queue.file.exception.QueueWriteException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sample producer that writes simple string messages using BaseController.
+ */
+public class ProducerSample implements Runnable {
+    private static final Logger logger = LoggerFactory.getLogger(ProducerSample.class);
+
+    private final BaseController controller;
+    private volatile boolean run = true;
+
+    public ProducerSample(BaseController controller) {
+        this.controller = controller;
+    }
+
+    @Override
+    public void run() {
+        int count = 0;
+        while (run && count < 100) {
+            try {
+                String data = "sample-" + count;
+                controller.write(data);
+                count++;
+            } catch (QueueWriteException e) {
+                run = false;
+                throw new RuntimeException(e);
+            }
+        }
+        logger.info("producer finished: {} messages", count);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ProducerSample` that writes messages using `BaseController`
- add `ConsumerSample` that reads messages using `BaseController`

## Testing
- `mvn -q test` *(fails: Failed to read artifact descriptor)*

------
https://chatgpt.com/codex/tasks/task_e_688174fcb034832cad415f2ceda0e868